### PR TITLE
util: Fix reference to `config.py`

### DIFF
--- a/util/utils.py
+++ b/util/utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import sys
 import typing as tp
 
-import config
+from util import config
 
 try:
     import cxxfilt


### PR DESCRIPTION
Adding the parent folder name as `import from` fixes the importing error on this file, fixing a lot of script files using this file (also `progress.py`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/2)
<!-- Reviewable:end -->
