### PR TITLE
Cleanup of Ghidra scripts

### DIFF
--- a/ghidra_scripts/DWARF.java
+++ b/ghidra_scripts/DWARF.java
@@ -1,0 +1,39 @@
+// Imports DWARF information from the compiled version of a program.
+// To use in decompilation efforts, drag and drop from the compiled version's Data Type Manager, into the original Switch version's.
+// This script is very similar to Ghidra's "DWARF_ExtractorScript.java", but disables function-related generation for speed and clarity.
+//@author OpenEAD
+//@category NX-Switch
+
+import ghidra.app.script.GhidraScript;
+import ghidra.app.util.bin.format.dwarf4.next.DWARFProgram;
+import ghidra.app.util.bin.format.dwarf4.next.DWARFImportOptions;
+import ghidra.app.util.bin.format.dwarf4.next.DWARFParser;
+import ghidra.app.util.bin.format.dwarf4.next.DWARFImportSummary;
+import ghidra.program.model.data.BuiltInDataTypeManager;
+
+public class DWARF extends GhidraScript {
+	@Override
+	public void run() throws Exception {
+		if (!DWARFProgram.isDWARF(currentProgram)) {
+			popup("Unable to find DWARF information, aborting");
+			return;
+		}
+
+		DWARFImportOptions importOptions = new DWARFImportOptions();
+
+		// These clutter the types, and take ages to generate.
+		// That's why they're disabled.
+		importOptions.setCreateFuncSignatures(false);
+		importOptions.setImportFuncs(false);
+
+		// Default is too low
+		importOptions.setImportLimitDIECount(Integer.MAX_VALUE);
+
+		try (DWARFProgram dwarfProg = new DWARFProgram(currentProgram, importOptions, monitor)) {
+			BuiltInDataTypeManager dtms = BuiltInDataTypeManager.getDataTypeManager();
+			DWARFParser dp = new DWARFParser(dwarfProg, dtms, monitor);
+			DWARFImportSummary importSummary = dp.parse();
+			importSummary.logSummaryResults();
+		}
+	}
+}

--- a/ghidra_scripts/README.md
+++ b/ghidra_scripts/README.md
@@ -1,0 +1,4 @@
+# Usage instructions:
+1. Open the `Script Manager` (green play icon) from Ghidra's toolbar.
+2. Click on `Manage Script Directories` (bullet points icon) inside the Script Manager, and add this directory.
+3. Select the `NX-Switch` category, and use the scripts provided. Information and instructions for each individual script are shown inside the Script Manager.


### PR DESCRIPTION
- Attempt to fix renaming of functions upon second run of script
- Filter prefixes to match IDA equivalent script
- Don't force specific body when it might cause weird issues with decompilation
- Add script for DWARF
- Add a lot of documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/4)
<!-- Reviewable:end -->
