### PR TITLE
Add versioning to all python scripts

### DIFF
--- a/diff_settings.py
+++ b/diff_settings.py
@@ -12,16 +12,29 @@ def get_tools_bin_dir():
     return ""
 
 
+def add_custom_arguments(parser):
+    parser.add_argument('--version', dest='version', help='Specify which version should be recompiled on source changes')
+
+
 def apply(config, args):
     root = util.config.get_repo_root()
+    version = args.version
+    if version is None:
+        version = util.config.get_default_version()
+
     config['arch'] = 'aarch64'
-    config['baseimg'] = util.config.get_base_elf()
-    config['myimg'] = util.config.get_decomp_elf()
+    config['baseimg'] = util.config.get_base_elf(version)
+    config['myimg'] = util.config.get_decomp_elf(version)
     config['source_directories'] = [str(root / 'src'), str(root / 'lib')]
     config['objdump_executable'] = get_tools_bin_dir() + 'aarch64-none-elf-objdump'
     # ill-suited to C++ projects (and too slow for large executables)
     config['show_line_numbers_default'] = False
     for dir in (root / 'build', root / 'build/nx64-release'):
+        if (dir / 'build.ninja').is_file():
+            config['make_command'] = ['ninja', '-C', str(dir)]
+    
+    if version is not None:
+        dir = root / 'build' / version
         if (dir / 'build.ninja').is_file():
             config['make_command'] = ['ninja', '-C', str(dir)]
 

--- a/setup_common.py
+++ b/setup_common.py
@@ -7,9 +7,23 @@ import tarfile
 import tempfile
 import urllib.request
 
+from util import config
+
 ROOT = Path(__file__).parent.parent.parent
-TARGET_PATH = ROOT / "data" / "main.nso"
-TARGET_ELF_PATH = ROOT / "data" / "main.elf"
+
+def get_target_path(version = config.get_default_version()):
+    value = ROOT / "data"
+    if version is not None:
+        value /= version
+    
+    return value / "main.nso"
+
+def get_target_elf_path(version = config.get_default_version()):
+    value = ROOT / "data"
+    if version is not None:
+        value /= version
+    
+    return value / "main.elf"
 
 
 def fail(error: str):

--- a/util/config.py
+++ b/util/config.py
@@ -1,20 +1,40 @@
 from pathlib import Path
 import toml
 
-def get_functions_csv_path() -> Path:
-    return get_repo_root() / load_toml()["functions_csv"]
-
-def get_base_elf() -> Path:
-    return get_repo_root() / 'data/main.elf'
-
-def get_decomp_elf() -> Path:
-    return get_repo_root() / "build" / get_build_target()
-
-def get_build_target() -> str:
-    return load_toml()["build_target"]
-
-def load_toml() -> toml:
-    return toml.load(get_repo_root() / "tools" / "config.toml")
 
 def get_repo_root() -> Path:
     return Path(__file__).resolve().parent.parent.parent.parent
+
+CONFIG = toml.load(get_repo_root() / "tools" / "config.toml")
+
+def get_default_version() -> str:
+    return CONFIG.get("default_version")
+
+def get_functions_csv_path(version = get_default_version()) -> Path:
+    value = CONFIG["functions_csv"]
+    if version is not None:
+        value = value.replace("{version}", version)
+    
+    if "{version}" in value:
+        raise RuntimeError("You should probably pass a --version parameter. If this error still shows up with the argument given, please contact the repo maintainers.")
+
+    return get_repo_root() / value
+
+def get_base_elf(version = get_default_version()) -> Path:
+    value = get_repo_root() / 'data'
+
+    if version is not None:
+        value /= version
+
+    return value / 'main.elf'
+
+def get_build_target() -> str:
+    return CONFIG["build_target"]
+
+def get_decomp_elf(version = get_default_version()) -> Path:
+    value = get_repo_root() / 'build'
+
+    if version is not None:
+        value /= version
+
+    return value / get_build_target()

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -233,11 +233,18 @@ fn check_single(
     }
 
     if should_show_diff {
-        let diff_args = args
+        let mut diff_args: Vec<String> = args
             .iter()
-            .filter(|s| s.as_str() != fn_to_check && s.as_str() != "--always-diff" && !s.as_str().starts_with("--version="));
+            .filter(|s| s.as_str() != fn_to_check && s.as_str() != "--always-diff" && !s.as_str().starts_with("--version="))
+            .cloned()
+            .collect();
 
         let differ_path = repo::get_tools_path()?.join("asm-differ").join("diff.py");
+
+        if version.is_some() {
+            diff_args.push("--version".to_owned());
+            diff_args.push(version.unwrap().to_owned());
+        }
 
         std::process::Command::new(&differ_path)
             .current_dir(repo::get_tools_path()?)


### PR DESCRIPTION
This PR adds versioning aibility to all python scripts. So far, it's mainly unused, but it will always default to the version specified in the `config.toml`. 

This PR also adjusts the paths that can be used by python scripts, for the original and decomp ELF. They still default to the same path as before, but if the `version` parameter is specified, the version-specific path is used instead.

To have `asm-differ` only re-compile the specific version currently in-edit, `viking` needs to pass the `version` on to `diff_settings.py`. This is done by adding a custom parameter, that is then read in the settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/7)
<!-- Reviewable:end -->
