### PR TITLE
setup_common: Fix import error on call from root

### DIFF
--- a/setup_common.py
+++ b/setup_common.py
@@ -7,7 +7,7 @@ import tarfile
 import tempfile
 import urllib.request
 
-from util import config
+from common.util import config
 
 ROOT = Path(__file__).parent.parent.parent
 


### PR DESCRIPTION
This change should be pretty straight forward: As the setup is always called from one level higher, `setup_common.py` also has to use the higher directory path for importing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/8)
<!-- Reviewable:end -->
