### PR TITLE
Add versioning to `data_symbols.csv`

### DIFF
--- a/setup_common.py
+++ b/setup_common.py
@@ -12,18 +12,10 @@ from common.util import config
 ROOT = Path(__file__).parent.parent.parent
 
 def get_target_path(version = config.get_default_version()):
-    value = ROOT / "data"
-    if version is not None:
-        value /= version
-    
-    return value / "main.nso"
+    return config.get_versioned_data_path(version) / "main.nso"
 
 def get_target_elf_path(version = config.get_default_version()):
-    value = ROOT / "data"
-    if version is not None:
-        value /= version
-    
-    return value / "main.elf"
+    return config.get_versioned_data_path(version) / "main.elf"
 
 
 def fail(error: str):

--- a/util/checker.py
+++ b/util/checker.py
@@ -1,10 +1,11 @@
 import struct
 from collections import defaultdict
 from typing import Set, DefaultDict, Dict, Optional, Tuple
+from pathlib import Path
 
 import capstone as cs
 
-from . import dsym, elf, utils
+from . import dsym, elf, utils, config
 
 _store_instructions = ("str", "strb", "strh", "stur", "sturb", "sturh")
 
@@ -38,9 +39,12 @@ class FunctionChecker:
     def get_mismatch(self) -> (int, int, str):
         return self._mismatch_addr1, self._mismatch_addr2, self._mismatch_cause
 
+    def get_data_symbols_path(self, version = config.get_default_version()) -> Path:
+        return config.get_versioned_data_path(version) / "data_symbols.csv"
+
     def load_data_for_project(self) -> None:
         self.decompiled_fns = {func.addr: func.decomp_name for func in utils.get_functions() if func.decomp_name}
-        self.get_data_symtab().load_from_csv(utils.get_repo_root() / "data" / "data_symbols.csv")
+        self.get_data_symtab().load_from_csv(self.get_data_symbols_path())
 
     def check(self, base_fn: elf.Function, my_fn: elf.Function) -> bool:
         self._reset_mismatch()

--- a/util/config.py
+++ b/util/config.py
@@ -10,6 +10,14 @@ CONFIG = toml.load(get_repo_root() / "tools" / "config.toml")
 def get_default_version() -> str:
     return CONFIG.get("default_version")
 
+def get_versioned_data_path(version = get_default_version()) -> Path:
+    value = get_repo_root() / 'data'
+
+    if version is not None:
+        value /= version
+    
+    return value
+
 def get_functions_csv_path(version = None) -> Path:
     value = CONFIG["functions_csv"]
     if version is None:
@@ -24,12 +32,7 @@ def get_functions_csv_path(version = None) -> Path:
     return get_repo_root() / value
 
 def get_base_elf(version = get_default_version()) -> Path:
-    value = get_repo_root() / 'data'
-
-    if version is not None:
-        value /= version
-
-    return value / 'main.elf'
+    return get_versioned_data_path() / 'main.elf'
 
 def get_build_target() -> str:
     return CONFIG["build_target"]

--- a/viking/src/checks.rs
+++ b/viking/src/checks.rs
@@ -91,11 +91,8 @@ impl KnownDataSymbolMap {
     }
 }
 
-fn get_data_symbol_csv_path() -> Result<PathBuf> {
-    let mut path = repo::get_repo_root()?;
-    path.push("data");
-    path.push("data_symbols.csv");
-    Ok(path)
+fn get_data_symbol_csv_path(version: &Option<&str>) -> Result<PathBuf> {
+    Ok(repo::get_data_path(version)?.join("data_symbols.csv"))
 }
 
 #[derive(Debug)]
@@ -193,9 +190,10 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
         decomp_symtab: &'a elf::SymbolTableByName<'decomp_elf>,
         decomp_glob_data_table: elf::GlobDataTable,
         functions: &'functions [functions::Info],
+        version: &Option<&str>,
     ) -> Result<Self> {
         let mut known_data_symbols = KnownDataSymbolMap::new();
-        known_data_symbols.load(get_data_symbol_csv_path()?.as_path(), decomp_symtab)?;
+        known_data_symbols.load(get_data_symbol_csv_path(version)?.as_path(), decomp_symtab)?;
 
         let known_functions = functions::make_known_function_map(functions);
         let orig_got_section = elf::find_section(orig_elf, ".got")?;

--- a/viking/src/elf.rs
+++ b/viking/src/elf.rs
@@ -103,15 +103,7 @@ pub fn load_elf(path: &Path) -> Result<OwnedElf> {
 }
 
 pub fn load_orig_elf(version: &Option<&str>) -> Result<OwnedElf> {
-    let mut path = repo::get_repo_root()?;
-    let data_name = if version.is_some() {
-        format!("data/{}", version.as_ref().unwrap())
-    } else {
-        "data".to_string()
-    };
-    path.push(data_name);
-    path.push("main.elf");
-    load_elf(path.as_path())
+    load_elf(repo::get_data_path(version)?.join("main.elf").as_path())
 }
 
 pub fn load_decomp_elf(version: &Option<&str>) -> Result<OwnedElf> {

--- a/viking/src/repo.rs
+++ b/viking/src/repo.rs
@@ -32,3 +32,13 @@ pub fn get_repo_root() -> Result<PathBuf> {
 pub fn get_tools_path() -> Result<PathBuf> {
     Ok(get_repo_root()?.join("tools/common"))
 }
+
+pub fn get_data_path(version: &Option<&str>) -> Result<PathBuf> {
+    let data_dir_name = if let Some(v) = version {
+        format!("data/{}", v)
+    } else {
+        "data".to_string()
+    };
+
+    Ok(get_repo_root()?.join(data_dir_name))
+}

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -317,6 +317,7 @@ fn main() -> Result<()> {
         &decomp_symtab,
         decomp_glob_data_table,
         &functions,
+        &version,
     )
     .context("failed to construct FunctionChecker")?;
 
@@ -334,7 +335,7 @@ fn main() -> Result<()> {
             &decomp_elf,
             &decomp_symtab,
             &args,
-            &version
+            &version,
         )?;
     } else {
         // Normal check mode.


### PR DESCRIPTION
Along with moving all required data files into version-respective paths, the `data_symbols.csv`-table should also found in a version-dependent location, so it can easily be swapped for checking different version.

This PR moves them into `data/{version}/data_symbols.csv`, next to the `_functions.csv`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/9)
<!-- Reviewable:end -->
