### PR TITLE
`viking`: Fix usage of data_symbols

### DIFF
--- a/viking/src/checks.rs
+++ b/viking/src/checks.rs
@@ -481,9 +481,8 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
             return None;
         }
 
-        let orig_offset = elf::get_offset_in_file(self.orig_elf, orig_addr_ptr).ok()? as u64;
         let orig_addr = u64::from_le_bytes(
-            elf::get_elf_bytes(self.orig_elf, orig_offset, 8)
+            elf::get_elf_bytes(self.orig_elf, orig_addr_ptr, 8)
                 .ok()?
                 .try_into()
                 .ok()?,


### PR DESCRIPTION
When trying to resolve data symbol-pointers, the checker tries to account the file offset of the pointer twice: Once in the `check_data_symbol_ptr` itself, and once again when calling `elf::get_bytes`. This lead to the pointers pointing to a wrong offset, resolving into different data structures and thus displaying (nonexistant) errors or just failing to resolve due to an out-of-bounds read.

This PR fixes this behaviour, by removing the manual offset calculation from this class and just letting that handle the `elf` class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/10)
<!-- Reviewable:end -->
