### PR TITLE
`viking`: Add `--update_matching`

### DIFF
--- a/viking/Cargo.lock
+++ b/viking/Cargo.lock
@@ -344,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexopt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7513aea7d10dc0694d719ac53de3b74f1600e41b9f81ed9f395d8ec36a2a70"
+
+[[package]]
 name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +778,7 @@ dependencies = [
  "itertools",
  "lazy-init",
  "lazy_static",
+ "lexopt",
  "memmap",
  "mimalloc",
  "owning_ref",

--- a/viking/Cargo.toml
+++ b/viking/Cargo.toml
@@ -21,6 +21,7 @@ inquire = "0.2.1"
 itertools = "0.10.1"
 lazy-init = "0.5.0"
 lazy_static = "1.4.0"
+lexopt = "0.2.0"
 memmap = "0.6.1"
 mimalloc = { version = "*", default-features = false }
 owning_ref = "0.4.1"


### PR DESCRIPTION
This PR adds an additional argument for checking multiple functions: `--update_matching` will set all functions in the database to `O` when they're matching, and currently not marked in such a way.

This is particularly useful when a complete function table is already given/known, and their matching functions are also already decompiled. This may be the case when adding a new version to the decompile, or when accidentally reversing changes on the function database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/11)
<!-- Reviewable:end -->
