### PR TITLE
`progress.py`: Add `--version`

### DIFF
--- a/progress.py
+++ b/progress.py
@@ -15,6 +15,8 @@ parser.add_argument("--print-eq", "-e", action="store_true",
                     help="Print non-matching functions with minor issues")
 parser.add_argument("--print-ok", "-m", action="store_true",
                     help="Print matching functions")
+parser.add_argument("--version",
+                    help="Specify which version to load CSV from")
 args = parser.parse_args()
 
 code_size_total = 0
@@ -22,7 +24,7 @@ num_total = 0
 code_size: tp.DefaultDict[FunctionStatus, int] = defaultdict(int)
 counts: tp.DefaultDict[FunctionStatus, int] = defaultdict(int)
 
-for info in utils.get_functions():
+for info in utils.get_functions(version=args.version):
     code_size_total += info.size
     num_total += 1
 

--- a/util/config.py
+++ b/util/config.py
@@ -10,8 +10,11 @@ CONFIG = toml.load(get_repo_root() / "tools" / "config.toml")
 def get_default_version() -> str:
     return CONFIG.get("default_version")
 
-def get_functions_csv_path(version = get_default_version()) -> Path:
+def get_functions_csv_path(version = None) -> Path:
     value = CONFIG["functions_csv"]
+    if version is None:
+        version = get_default_version()
+    
     if version is not None:
         value = value.replace("{version}", version)
     

--- a/util/utils.py
+++ b/util/utils.py
@@ -57,13 +57,13 @@ def parse_function_csv_entry(row) -> FunctionInfo:
     return FunctionInfo(addr, name, int(size), decomp_name, stat == "L", status, row)
 
 
-def get_functions_csv_path() -> Path:
-    return config.get_functions_csv_path()
+def get_functions_csv_path(version = None) -> Path:
+    return config.get_functions_csv_path(version)
 
 
-def get_functions(path: tp.Optional[Path] = None) -> tp.Iterable[FunctionInfo]:
+def get_functions(path: tp.Optional[Path] = None, version = None) -> tp.Iterable[FunctionInfo]:
     if path is None:
-        path = get_functions_csv_path()
+        path = get_functions_csv_path(version)
     with path.open() as f:
         reader = csv.reader(f)
         # Skip headers


### PR DESCRIPTION
To achieve this, the `util/config.py` file has been slightly adjusted, so that it will now try to re-load the default `version` if `None` is passed as a parameter. This is to prevent having to manually specify `config.get_default_version` as default value for the parameter on all levels: Instead, just use `None` and let the util functions handle the remaining part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/12)
<!-- Reviewable:end -->
