### PR TITLE
Fix dir_name for llvm+clang on macOS

### DIFF
--- a/setup_common.py
+++ b/setup_common.py
@@ -88,11 +88,11 @@ def set_up_compiler(version):
             # macOS
             ("Darwin", "x86_64"): {
                 "url": "https://releases.llvm.org/4.0.1/clang+llvm-4.0.1-x86_64-apple-darwin.tar.xz",
-                "dir_name": "clang+llvm-4.0.1-x86_64-apple-darwin",
+                "dir_name": "clang+llvm-4.0.1-x86_64-apple-macosx10.9.0",
             },
             ("Darwin", "aarch64"): {
                 "url": "https://releases.llvm.org/4.0.1/clang+llvm-4.0.1-x86_64-apple-darwin.tar.xz",
-                "dir_name": "clang+llvm-4.0.1-x86_64-apple-darwin",
+                "dir_name": "clang+llvm-4.0.1-x86_64-apple-macosx10.9.0",
             },
         }
     else:


### PR DESCRIPTION
Fix dir_name for llvm+clang on macOS

Should be: `clang+llvm-4.0.1-x86_64-apple-macosx10.9.0`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/14)
<!-- Reviewable:end -->
