### PR TITLE
Python on Apple Silicon uses arm64, not aarch64 for platform.machine()

### DIFF
--- a/setup_common.py
+++ b/setup_common.py
@@ -90,7 +90,7 @@ def set_up_compiler(version):
                 "url": "https://releases.llvm.org/4.0.1/clang+llvm-4.0.1-x86_64-apple-darwin.tar.xz",
                 "dir_name": "clang+llvm-4.0.1-x86_64-apple-macosx10.9.0",
             },
-            ("Darwin", "aarch64"): {
+            ("Darwin", "arm64"): {
                 "url": "https://releases.llvm.org/4.0.1/clang+llvm-4.0.1-x86_64-apple-darwin.tar.xz",
                 "dir_name": "clang+llvm-4.0.1-x86_64-apple-macosx10.9.0",
             },


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/15)
<!-- Reviewable:end -->
