### PR TITLE
Change to LLVM-Objdump for asm-differ

### DIFF
--- a/diff_settings.py
+++ b/diff_settings.py
@@ -34,7 +34,7 @@ def apply(config, args):
     config['baseimg'] = util.config.get_base_elf(version)
     config['myimg'] = util.config.get_decomp_elf(version)
     config['source_directories'] = [str(root / 'src'), str(root / 'lib')]
-    config['objdump_executable'] = "llvm-objdump"
+    config['objdump_executable'] = get_tools_bin_dir() + 'llvm-objdump'
     # ill-suited to C++ projects (and too slow for large executables)
     config['show_line_numbers_default'] = False
     for dir in (root / 'build', root / 'build/nx64-release'):


### PR DESCRIPTION
As discussed earlier, we want to switch from using `gnu-objdump` to `llvm-objdump`, as this fixes some (all?) of the issues we were having in SMO with multiple symbols being defined at a single address. This PR is part two of the "transitioning process", after the first one has been accidentally committed to the main branch directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/24)
<!-- Reviewable:end -->
