### PR TITLE
Skip GOT segment option

### DIFF
--- a/viking/src/checks.rs
+++ b/viking/src/checks.rs
@@ -178,7 +178,7 @@ pub struct FunctionChecker<'a, 'functions, 'orig_elf, 'decomp_elf> {
     known_functions: FxHashMap<u64, &'functions functions::Info>,
 
     pub orig_elf: &'orig_elf elf::OwnedElf,
-    orig_got_section: &'orig_elf goblin::elf::SectionHeader,
+    orig_got_section: Option<&'orig_elf goblin::elf::SectionHeader>,
 }
 
 impl<'a, 'functions, 'orig_elf, 'decomp_elf>
@@ -196,7 +196,8 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
         known_data_symbols.load(get_data_symbol_csv_path(version)?.as_path(), decomp_symtab)?;
 
         let known_functions = functions::make_known_function_map(functions);
-        let orig_got_section = elf::find_section(orig_elf, ".got")?;
+        
+        let orig_got_section = elf::find_section(orig_elf, ".got").ok();
 
         Ok(FunctionChecker {
             decomp_elf,
@@ -475,7 +476,7 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
         orig_addr_ptr: u64,
         decomp_addr_ptr: u64,
     ) -> Option<MismatchCause> {
-        if !elf::is_in_section(self.orig_got_section, orig_addr_ptr, 8) {
+        if !elf::is_in_section(self.orig_got_section?, orig_addr_ptr, 8) {
             return None;
         }
 


### PR DESCRIPTION
Adding an option to skip the check for GOT segment. not sure why it exists, but if there are games (there are) that dont have one, they just specify skip_got_segment as true in config.toml.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/26)
<!-- Reviewable:end -->
