### PR TITLE
viking: fix build error on aarch64 linux

### DIFF
--- a/viking/src/elf.rs
+++ b/viking/src/elf.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, ffi::CStr, fs::File, ops::Range, path::Path, path::PathBuf};
+use std::{
+    collections::HashMap,
+    ffi::{c_char, CStr},
+    fs::File,
+    ops::Range,
+    path::Path,
+    path::PathBuf,
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use goblin::{
@@ -145,7 +152,7 @@ impl<'elf> SymbolStringTable<'elf> {
     pub fn get_string(&self, offset: usize) -> &'elf str {
         unsafe {
             std::str::from_utf8_unchecked(
-                CStr::from_ptr(self.bytes[offset..self.bytes.len()].as_ptr() as *const i8)
+                CStr::from_ptr(self.bytes[offset..self.bytes.len()].as_ptr() as *const c_char)
                     .to_bytes(),
             )
         }


### PR DESCRIPTION
`char` is unsigned on that platform.

```text
error[E0308]: mismatched types
   --> src/elf.rs:148:32
    |
148 |                 CStr::from_ptr(self.bytes[offset..self.bytes.len()].as_ptr() as *const i8)
    |                 -------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
    |                 |
    |                 arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: associated function defined here
   --> /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/ffi/c_str.rs:276:25
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/27)
<!-- Reviewable:end -->
