### PR TITLE
Add support for tools finding tools from the path

### DIFF
--- a/diff_settings.py
+++ b/diff_settings.py
@@ -1,16 +1,7 @@
 from pathlib import Path
 import platform
 import util.config
-
-def get_tools_bin_dir():
-    path = util.config.get_repo_root() / 'tools' / 'common' / 'nx-decomp-tools-binaries'
-    system = platform.system()
-    if system == "Linux":
-        return str(path) + "/linux/"
-    if system == "Darwin":
-        return str(path) + "/macos/"
-    return ""
-
+from util.tools import find_tool
 
 def add_custom_arguments(parser):
     parser.add_argument('--version', dest='version', help='Specify which version should be recompiled on source changes')
@@ -34,7 +25,7 @@ def apply(config, args):
     config['baseimg'] = util.config.get_base_elf(version)
     config['myimg'] = util.config.get_decomp_elf(version)
     config['source_directories'] = [str(root / 'src'), str(root / 'lib')]
-    config['objdump_executable'] = get_tools_bin_dir() + 'llvm-objdump'
+    config['objdump_executable'] = find_tool('llvm-objdump')
     # ill-suited to C++ projects (and too slow for large executables)
     config['show_line_numbers_default'] = False
     for dir in (root / 'build', root / 'build/nx64-release'):

--- a/setup_common.py
+++ b/setup_common.py
@@ -36,16 +36,13 @@ def _decompress_nso(nso_path: Path, dest_path: Path):
 def install_viking():
     src_path = ROOT / "tools" / "common" / "viking"
     install_path = ROOT / "tools"
-    tools = ["check", "listsym", "decompme"]
-
-    if all(os.path.exists(install_path / file_name) for file_name in tools):
-        return
+    tool_names = ["check", "listsym", "decompme"]
 
     print(">>>> installing viking (tools/check)")
 
     try:
         subprocess.check_call(["cargo", "build", "--manifest-path", src_path / "Cargo.toml", "--release"])
-        for tool in tools:
+        for tool in tool_names:
             (src_path / "target" / "release" / tool).rename(install_path / tool)
     except FileNotFoundError:
         print(sys.exc_info()[0])

--- a/setup_common.py
+++ b/setup_common.py
@@ -34,15 +34,13 @@ def _decompress_nso(nso_path: Path, dest_path: Path):
                            "--uncompressed=" + str(dest_path), str(nso_path)])
 
 def install_viking():
+    print(">>>> installing viking (tools/check)")
     src_path = ROOT / "tools" / "common" / "viking"
     install_path = ROOT / "tools"
-    tool_names = ["check", "listsym", "decompme"]
-
-    print(">>>> installing viking (tools/check)")
-
+    
     try:
         subprocess.check_call(["cargo", "build", "--manifest-path", src_path / "Cargo.toml", "--release"])
-        for tool in tool_names:
+        for tool in ["check", "listsym", "decompme"]:
             (src_path / "target" / "release" / tool).rename(install_path / tool)
     except FileNotFoundError:
         print(sys.exc_info()[0])

--- a/setup_common.py
+++ b/setup_common.py
@@ -1,5 +1,3 @@
-import os
-import shutil
 import platform
 from pathlib import Path
 import subprocess
@@ -37,7 +35,7 @@ def install_viking():
     print(">>>> installing viking (tools/check)")
     src_path = ROOT / "tools" / "common" / "viking"
     install_path = ROOT / "tools"
-    
+
     try:
         subprocess.check_call(["cargo", "build", "--manifest-path", src_path / "Cargo.toml", "--release"])
         for tool in ["check", "listsym", "decompme"]:

--- a/setup_common.py
+++ b/setup_common.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import platform
 from pathlib import Path
 import subprocess
@@ -7,7 +8,7 @@ import tarfile
 import tempfile
 import urllib.request
 
-from common.util import config
+from common.util import config, tools
 
 ROOT = Path(__file__).parent.parent.parent
 
@@ -22,36 +23,29 @@ def fail(error: str):
     print(">>> " + error)
     sys.exit(1)
 
-
-def _get_tool_binary_path():
-    base = ROOT / "tools" / "common" / "nx-decomp-tools-binaries"
-    system = platform.system()
-    if system == "Linux":
-        return str(base / "linux") + "/"
-    if system == "Darwin":
-        return str(base / "macos") + "/"
-    return ""
-
-
 def _convert_nso_to_elf(nso_path: Path):
     print(">>>> converting NSO to ELF...")
-    binpath = _get_tool_binary_path()
-    subprocess.check_call([binpath + "nx2elf", str(nso_path)])
+    subprocess.check_call([tools.find_tool("nx2elf"), str(nso_path)])
 
 
 def _decompress_nso(nso_path: Path, dest_path: Path):
     print(">>>> decompressing NSO...")
-    binpath = _get_tool_binary_path()
-    subprocess.check_call([binpath + "hactool", "-tnso",
+    subprocess.check_call([tools.find_tool("hactool"), "-tnso",
                            "--uncompressed=" + str(dest_path), str(nso_path)])
 
 def install_viking():
-    print(">>>> installing viking (tools/check)")
     src_path = ROOT / "tools" / "common" / "viking"
     install_path = ROOT / "tools"
+    tools = ["check", "listsym", "decompme"]
+
+    if all(os.path.exists(install_path / file_name) for file_name in tools):
+        return
+
+    print(">>>> installing viking (tools/check)")
+
     try:
         subprocess.check_call(["cargo", "build", "--manifest-path", src_path / "Cargo.toml", "--release"])
-        for tool in ["check", "listsym", "decompme"]:
+        for tool in tools:
             (src_path / "target" / "release" / tool).rename(install_path / tool)
     except FileNotFoundError:
         print(sys.exc_info()[0])

--- a/util/tools.py
+++ b/util/tools.py
@@ -12,7 +12,7 @@ def get_tools_bin_dir():
     return ""
 
 def try_find_external_tool(tool: str):
-    return os.environ.get("NX_DECOMP_TOOLS_%s" % tool.upper())
+    return os.environ.get("NX_DECOMP_TOOLS_%s" % tool.upper().replace("-", "_"))
 
 def find_tool(tool: str):
     tool_from_env = try_find_external_tool(tool)

--- a/util/tools.py
+++ b/util/tools.py
@@ -1,7 +1,6 @@
 from . config import get_repo_root
 import platform
 import os
-import shutil
 
 def get_tools_bin_dir():
     path = get_repo_root() / 'tools' / 'common' / 'nx-decomp-tools-binaries'
@@ -12,9 +11,10 @@ def get_tools_bin_dir():
         return str(path) + "/macos/"
     return ""
 
-def find_tool(tool):
-    executable = shutil.which(tool)
-    if executable is not None:
-        return executable
+def find_tool(tool: str):
+    tool_from_env = os.environ.get("NX_DECOMP_TOOLS_%s" % tool.upper())
 
-    return _get_tool_binary_path() + tool
+    if tool_from_env is None:
+        return get_tools_bin_dir() + tool
+
+    return tool_from_env

--- a/util/tools.py
+++ b/util/tools.py
@@ -1,0 +1,20 @@
+from . config import get_repo_root
+import platform
+import os
+import shutil
+
+def get_tools_bin_dir():
+    path = get_repo_root() / 'tools' / 'common' / 'nx-decomp-tools-binaries'
+    system = platform.system()
+    if system == "Linux":
+        return str(path) + "/linux/"
+    if system == "Darwin":
+        return str(path) + "/macos/"
+    return ""
+
+def find_tool(tool):
+    executable = shutil.which(tool)
+    if executable is not None:
+        return executable
+
+    return _get_tool_binary_path() + tool

--- a/util/tools.py
+++ b/util/tools.py
@@ -11,8 +11,11 @@ def get_tools_bin_dir():
         return str(path) + "/macos/"
     return ""
 
+def try_find_external_tool(tool: str):
+    return os.environ.get("NX_DECOMP_TOOLS_%s" % tool.upper())
+
 def find_tool(tool: str):
-    tool_from_env = os.environ.get("NX_DECOMP_TOOLS_%s" % tool.upper())
+    tool_from_env = try_find_external_tool(tool)
 
     if tool_from_env is None:
         return get_tools_bin_dir() + tool


### PR DESCRIPTION
I'm using NixOS and I want to be able to build all of the tools externally and supply them from nix, instead of relying on the binaries in the binary repository

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/28)
<!-- Reviewable:end -->
