### PR TITLE
Implement Preset ID

### DIFF
--- a/viking/src/repo.rs
+++ b/viking/src/repo.rs
@@ -17,6 +17,9 @@ pub struct ConfigDecompMe {
     /// Compilation flags that are used for creating scratches.
     /// Can be overridden using a compilation database.
     pub default_compile_flags: String,
+
+    /// Preset ID used for categorizing.
+    pub preset_id: String,
 }
 
 lazy_static! {

--- a/viking/src/tools/decompme.rs
+++ b/viking/src/tools/decompme.rs
@@ -217,6 +217,7 @@ fn create_scratch(
     context: &str,
     source_code: &str,
     disassembly: &str,
+    preset_id: &str,
 ) -> Result<String> {
     let client = reqwest::blocking::Client::new();
 
@@ -230,6 +231,7 @@ fn create_scratch(
         target_asm: String,
         source_code: String,
         context: String,
+        preset_id: String,
     }
 
     let data = Data {
@@ -241,6 +243,7 @@ fn create_scratch(
         target_asm: disassembly.to_string(),
         source_code: source_code.to_string(),
         context: context.to_string(),
+        preset_id: preset_id.to_string(),
     };
 
     let res_text = client
@@ -369,6 +372,7 @@ fn main() -> Result<()> {
         function_info.get_start(),
     );
 
+    let mut preset_id = decomp_me_config.preset_id.clone();
     let mut flags = decomp_me_config.default_compile_flags.clone();
     let mut context = "".to_string();
 
@@ -436,6 +440,7 @@ fn main() -> Result<()> {
         &context,
         &source_code,
         &disassembly,
+        &preset_id,
     )
     .context("failed to create scratch")?;
 


### PR DESCRIPTION
Here is my attempt to quickly implement it, I do not have much time to spend on this stuff rn, but i really felt like it. The preset ID is used to set the game label, such as "Super Mario Odyssey" instead of Custom Preset, and then it will be put into proper categories on said page.

Feel free to point out mistakes. Is it correct that value 0 is custom preset?
When visiting this page, preset 0 is invalid, so i guess it can be used as a default value.
https://decomp.me/api/preset/0
https://decomp.me/api/preset/1