### PR TITLE
Remove binaries repo submodule in favour of extended tool finding logic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "nx-decomp-tools-binaries"]
-	path = nx-decomp-tools-binaries
-	url = https://github.com/open-ead/nx-decomp-tools-binaries
 [submodule "asm-differ"]
 	path = asm-differ
 	url = https://github.com/simonlindholm/asm-differ

--- a/util/tools.py
+++ b/util/tools.py
@@ -9,7 +9,7 @@ def try_find_binaries_repo_tool(tool: str):
     tool_path = str(binaries_repo_path)
     if system == "Linux":
         tool_path += "/linux/"
-    if system == "Darwin":
+    elif system == "Darwin":
         tool_path += "/macos/"
     tool_path += tool
     if os.path.isfile(tool_path):

--- a/util/tools.py
+++ b/util/tools.py
@@ -1,23 +1,45 @@
 from . config import get_repo_root
 import platform
 import os
+import shutil
 
-def get_tools_bin_dir():
-    path = get_repo_root() / 'tools' / 'common' / 'nx-decomp-tools-binaries'
+def try_find_binaries_repo_tool(tool: str):
+    binaries_repo_path = get_repo_root() / 'toolchain' / 'nx-decomp-tools-binaries'
     system = platform.system()
+    tool_path = str(binaries_repo_path)
     if system == "Linux":
-        return str(path) + "/linux/"
+        tool_path += "/linux/"
     if system == "Darwin":
-        return str(path) + "/macos/"
-    return ""
+        tool_path += "/macos/"
+    tool_path += tool
+    if os.path.isfile(tool_path):
+        return tool_path
+    return None
+
+def try_find_toolchain_tool(tool: str):
+    toolchain_tool_path = get_repo_root() / 'toolchain' / 'bin' / tool
+    if os.path.isfile(toolchain_tool_path):
+        return str(toolchain_tool_path)
+    return None
+
+def try_find_global_tool(tool: str):
+    return shutil.which(tool)
 
 def try_find_external_tool(tool: str):
     return os.environ.get("NX_DECOMP_TOOLS_%s" % tool.upper().replace("-", "_"))
 
 def find_tool(tool: str):
-    tool_from_env = try_find_external_tool(tool)
+    if (tool_from_env := try_find_external_tool(tool)) is not None:
+        return tool_from_env
 
-    if tool_from_env is None:
-        return get_tools_bin_dir() + tool
+    if (tool_from_toolchain := try_find_toolchain_tool(tool)) is not None:
+        return tool_from_toolchain
 
-    return tool_from_env
+    if (tool_from_binaries_repo := try_find_binaries_repo_tool(tool)) is not None:
+        return tool_from_binaries_repo
+
+    if (tool_from_path := try_find_global_tool(tool)) is not None:
+        return tool_from_path
+
+    print(f"Could not find tool: {tool} (maybe install it manually?)")
+    exit(1)


### PR DESCRIPTION
For the SMO decomp, we have [MonsterDruide1/OdysseyDecompToolsCache](https://github.com/MonsterDruide1/OdysseyDecompToolsCache/) which has automatically built binaries of viking, clang 3.9 and lld 3.9. Then `setup.py` downloads these tools for the current platfrom. The idea is that `nx2elf` will soon be added to that repo too and `llvm-objdump` will just become a prerequisit for the project that the user needs to install in `PATH`. After that we don't need the binaries repo submodule for that decomp. For decomps that don't have a custom cache repo solution like that repo, the tool finding logic now expects the binaries repo to be a submodule of those decomp repos under `toolchain/nx-decomp-tools-binaries`. So the new tool finding goes like this: first check if the tool env var exists like before, if it doesn't try to find the tool from `toolchain/bin` instead (which is were the tools on `OdysseyDecompToolsCache` get extracted to) then if the tool can't be found from there look for it in `toolchain/nx-decomp-tools-binaries/PLATFORM` instead and if it isn't found from there either look for it in `PATH`. Then if none of those work, error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/33)
<!-- Reviewable:end -->
