### PR TITLE
`setup_common.py`: Make use of new `--export-uncompressed` `nx2elf` flag in `_convert_nso_to_elf`

### DIFF
--- a/setup_common.py
+++ b/setup_common.py
@@ -2,6 +2,7 @@ import platform
 from pathlib import Path
 import subprocess
 import sys
+import warnings
 import tarfile
 import tempfile
 import urllib.request
@@ -21,12 +22,16 @@ def fail(error: str):
     print(">>> " + error)
     sys.exit(1)
 
-def _convert_nso_to_elf(nso_path: Path):
+def _convert_nso_to_elf(nso_path: Path, export_uncompressed_nso=True):
     print(">>>> converting NSO to ELF...")
-    subprocess.check_call([tools.find_tool("nx2elf"), str(nso_path)])
+    command = [tools.find_tool("nx2elf"), str(nso_path)];
+    if export_uncompressed_nso:
+        command.append("--export-uncompressed")
+    subprocess.check_call(command)
 
 
 def _decompress_nso(nso_path: Path, dest_path: Path):
+    warnings.warn("Using hactool to decompress the target NSO is deprecated, please use `_convert_nso_to_elf` instead", DeprecationWarning, stacklevel=2)
     print(">>>> decompressing NSO...")
     subprocess.check_call([tools.find_tool("hactool"), "-tnso",
                            "--uncompressed=" + str(dest_path), str(nso_path)])


### PR DESCRIPTION
This PR changes `_convert_nso_to_elf` to pass in the new `--export-uncompressed` flag added by @MonsterDruide1 to `nx2elf`. I've also added a deprecation warning to `_decompress_nso` as that should no longer be used. Even after open-ead/nx-decomp-tools-binaries#2 is merged, the submodule won't be updated in this PR since #33 removes it entirely. Ig this PR should be merged after those two have been merged first, but this is technically not blocked by either PR (as giving the new flag to the old `nx2elf` doesn't give any errors)

Fixes #30

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/34)
<!-- Reviewable:end -->
