### PR TITLE
viking: Check calls to unimplemented functions

### DIFF
--- a/viking/src/checks.rs
+++ b/viking/src/checks.rs
@@ -420,24 +420,6 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
         Ok(None)
     }
 
-    fn plt_name_to_addr(elf: &elf::OwnedElf, func_name: &str) -> Option<u64> {
-        // find plt relocation for given function name
-        let (reloc_idx, _) = elf.pltrelocs.iter().enumerate().find(|(_, reloc)| {
-            elf.dynsyms.get(reloc.r_sym).map(|s| elf.dynstrtab.get_at(s.st_name)).flatten() == Some(func_name)
-        })?;
-
-        let plt_section = elf::find_section(elf, ".plt").ok()?;
-        Some(plt_section.sh_addr + (reloc_idx as u64 + 2) * 0x10)
-    }
-
-    fn plt_addr_to_name(elf: &elf::OwnedElf, addr: u64) -> Option<&str> {
-        let plt_section = elf::find_section(elf, ".plt").ok()?;
-        let reloc_idx = (addr - plt_section.sh_addr) / 16 - 2;
-        let reloc = elf.pltrelocs.get(reloc_idx as usize)?;
-        let name = elf.dynstrtab.get_at(elf.dynsyms.get(reloc.r_sym)?.st_name)?;
-        Some(name)
-    }
-
     /// Returns None on success and a MismatchCause on failure.
     fn check_function_call(&self, orig_addr: u64, decomp_addr: u64) -> Option<MismatchCause> {
         if !repo::get_config().check_unimplemented_references.unwrap_or(true) {
@@ -467,7 +449,7 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
             }))
         }
         let Some(expected) = self.decomp_symtab.get(name).map(|sym| sym.st_value)
-                .or_else(|| Self::plt_name_to_addr(self.decomp_elf, name)) else {
+                .or_else(|| elf::plt_name_to_addr(self.decomp_elf, name)) else {
             let actual_symbol_name = self.translate_decomp_addr_to_name(decomp_addr);
             return Some(MismatchCause::FunctionCall(ReferenceDiff {
                 referenced_symbol: orig_addr,
@@ -566,6 +548,6 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
             let map = elf::make_addr_to_name_map(self.decomp_elf).ok();
             map.unwrap_or_default()
         });
-        map.get(&decomp_addr).copied().or_else(|| Self::plt_addr_to_name(self.decomp_elf, decomp_addr))
+        map.get(&decomp_addr).copied().or_else(|| elf::plt_addr_to_name(self.decomp_elf, decomp_addr))
     }
 }

--- a/viking/src/elf.rs
+++ b/viking/src/elf.rs
@@ -22,7 +22,7 @@ use memmap::{Mmap, MmapOptions};
 use owning_ref::OwningHandle;
 use rustc_hash::FxHashMap;
 
-use crate::{repo, functions::{AddressLabel, Info, Status}};
+use crate::{repo, functions::{Info, Status}};
 
 pub type OwnedElf = OwningHandle<Box<(File, Mmap)>, Box<Elf<'static>>>;
 pub type SymbolTableByName<'a> = HashMap<&'a str, goblin::elf::Sym>;
@@ -312,8 +312,8 @@ pub fn get_plt_functions(elf: &OwnedElf) -> Result<Vec<crate::functions::Info>> 
         let sym = elf.dynsyms.get(reloc.r_sym).context("Failed to get dynsym")?;
         let name = elf.dynstrtab.get_at(sym.st_name).context("Failed to get dynstr")?;
         functions.push(Info {
-            offset: addr as u32, size: 0x10, label: AddressLabel::Single(name.to_string()), 
-            status: Status::Library, lazy: false, guess: false,
+            addr: addr, size: 0x10, name: name.to_string(), 
+            status: Status::Library,
         });
     }
 

--- a/viking/src/elf.rs
+++ b/viking/src/elf.rs
@@ -22,7 +22,7 @@ use memmap::{Mmap, MmapOptions};
 use owning_ref::OwningHandle;
 use rustc_hash::FxHashMap;
 
-use crate::repo;
+use crate::{repo, functions::{AddressLabel, Info, Status}};
 
 pub type OwnedElf = OwningHandle<Box<(File, Mmap)>, Box<Elf<'static>>>;
 pub type SymbolTableByName<'a> = HashMap<&'a str, goblin::elf::Sym>;
@@ -55,7 +55,7 @@ fn make_goblin_ctx() -> container::Ctx {
 
 /// A stripped down version of `goblin::elf::Elf::parse`, parsing only the sections that we need.
 ///
-/// *Warning*: In particular, `strtab`, `dynstrtab`, `soname` and `libraries` are **not** parsed.
+/// *Warning*: In particular, `strtab`, `soname` and `libraries` are **not** parsed.
 fn parse_elf_faster(bytes: &[u8]) -> Result<Elf<'_>> {
     let header = Elf::parse_header(bytes)?;
     let mut elf = Elf::lazy_parse(header)?;
@@ -97,6 +97,12 @@ fn parse_elf_faster(bytes: &[u8]) -> Result<Elf<'_>> {
         let is_rela = dyn_info.pltrel == dynamic::DT_RELA;
         elf.pltrelocs =
             RelocSection::parse(bytes, dyn_info.jmprel, dyn_info.pltrelsz, is_rela, ctx)?;
+
+        let hash_offset = dyn_info.hash.context("no hash")? as usize;
+        let num_syms = u32::from_le_bytes(bytes[hash_offset+4..hash_offset+8].try_into()?) as usize;
+        elf.dynsyms = Symtab::parse(bytes, dyn_info.symtab, num_syms, ctx)?;
+
+        elf.dynstrtab = Strtab::parse(bytes, dyn_info.strtab, dyn_info.strsz, 0x0)?;
     }
 
     Ok(elf)
@@ -294,6 +300,24 @@ pub fn build_glob_data_table(elf: &OwnedElf) -> Result<GlobDataTable> {
     }
 
     Ok(table)
+}
+
+pub fn get_plt_functions(elf: &OwnedElf) -> Result<Vec<crate::functions::Info>> {
+    let plt_section = find_section(elf, ".plt")?;
+    let mut functions = Vec::with_capacity(elf.pltrelocs.len());
+
+    for (idx, reloc) in elf.pltrelocs.iter().enumerate() {
+        // each PLT entry is 0x10 bytes, and the first (reserved) entry is twice the size
+        let addr = plt_section.sh_addr + (idx as u64 + 2) * 0x10;
+        let sym = elf.dynsyms.get(reloc.r_sym).context("Failed to get dynsym")?;
+        let name = elf.dynstrtab.get_at(sym.st_name).context("Failed to get dynstr")?;
+        functions.push(Info {
+            offset: addr as u32, size: 0x10, label: AddressLabel::Single(name.to_string()), 
+            status: Status::Library, lazy: false, guess: false,
+        });
+    }
+
+    Ok(functions)
 }
 
 pub fn get_offset_in_file(elf: &OwnedElf, addr: u64) -> Result<usize> {

--- a/viking/src/elf.rs
+++ b/viking/src/elf.rs
@@ -54,6 +54,7 @@ fn make_goblin_ctx() -> container::Ctx {
 }
 
 /// A stripped down version of `goblin::elf::Elf::parse`, parsing only the sections that we need.
+/// https://github.com/m4b/goblin/blob/86de3b4b04c49e2f80ec9ebd8f60c059b7213fb7/src/elf/mod.rs#L268
 ///
 /// *Warning*: In particular, `strtab`, `soname` and `libraries` are **not** parsed.
 fn parse_elf_faster(bytes: &[u8]) -> Result<Elf<'_>> {
@@ -99,6 +100,8 @@ fn parse_elf_faster(bytes: &[u8]) -> Result<Elf<'_>> {
             RelocSection::parse(bytes, dyn_info.jmprel, dyn_info.pltrelsz, is_rela, ctx)?;
 
         let hash_offset = dyn_info.hash.context("no hash")? as usize;
+        // number of symbols (entries in .hash section) is stored at offset 4
+        // (https://github.com/m4b/goblin/blob/86de3b4b04c49e2f80ec9ebd8f60c059b7213fb7/src/elf/mod.rs#L519)
         let num_syms = u32::from_le_bytes(bytes[hash_offset+4..hash_offset+8].try_into()?) as usize;
         elf.dynsyms = Symtab::parse(bytes, dyn_info.symtab, num_syms, ctx)?;
 
@@ -390,4 +393,22 @@ pub fn find_file_and_line_by_symbol(
     let file = loc.file.context("no file found")?;
     let line = loc.line.context("no line found")?;
     Ok((file.to_string(), line))
+}
+
+pub fn plt_name_to_addr(elf: &OwnedElf, func_name: &str) -> Option<u64> {
+    // find plt relocation for given function name
+    let reloc_idx = elf.pltrelocs.iter().position(|reloc| {
+        elf.dynsyms.get(reloc.r_sym).map(|s| elf.dynstrtab.get_at(s.st_name)).flatten() == Some(func_name)
+    })?;
+
+    let plt_section = find_section(elf, ".plt").ok()?;
+    Some(plt_section.sh_addr + (reloc_idx as u64 + 2) * 0x10)
+}
+
+pub fn plt_addr_to_name(elf: &OwnedElf, addr: u64) -> Option<&str> {
+    let plt_section = find_section(elf, ".plt").ok()?;
+    let reloc_idx = (addr - plt_section.sh_addr) / 16 - 2;
+    let reloc = elf.pltrelocs.get(reloc_idx as usize)?;
+    let name = elf.dynstrtab.get_at(elf.dynsyms.get(reloc.r_sym)?.st_name)?;
+    Some(name)
 }

--- a/viking/src/functions.rs
+++ b/viking/src/functions.rs
@@ -223,9 +223,6 @@ pub fn make_known_function_map(functions: &[Info]) -> FxHashMap<u64, &Info> {
         FxHashMap::with_capacity_and_hasher(functions.len(), Default::default());
 
     for function in functions {
-        if function.name.is_empty() {
-            continue;
-        }
         known_functions.insert(function.addr, function);
     }
 

--- a/viking/src/repo.rs
+++ b/viking/src/repo.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub functions_csv: String,
     pub default_version: Option<String>,
     pub decomp_me: Option<ConfigDecompMe>,
+    pub check_unimplemented_references: Option<bool>,
 }
 
 #[derive(serde::Deserialize)]

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -65,22 +65,25 @@ fn main() -> Result<()> {
     let mut decomp_symtab = None;
     let mut decomp_glob_data_table = None;
     let mut functions = None;
+    let mut plt_functions = None;
 
     rayon::scope(|s| {
         s.spawn(|_| decomp_symtab = Some(elf::make_symbol_map_by_name(&decomp_elf)));
         s.spawn(|_| decomp_glob_data_table = Some(elf::build_glob_data_table(&decomp_elf)));
         s.spawn(|_| functions = Some(functions::get_functions(version)));
+        s.spawn(|_| plt_functions = Some(elf::get_plt_functions(&orig_elf)));
     });
 
     let decomp_symtab = decomp_symtab
         .unwrap()
         .context("failed to make symbol map")?;
-
     let decomp_glob_data_table = decomp_glob_data_table
         .unwrap()
         .context("failed to make global data table")?;
 
     let functions = functions.unwrap().context("failed to load function CSV")?;
+    let plt_functions = plt_functions.unwrap().context("failed to load plt functions")?;
+    let functions = vec![file_functions, plt_functions].concat();
 
     let checker = FunctionChecker::new(
         &orig_elf,

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
 
     let functions = functions.unwrap().context("failed to load function CSV")?;
     let plt_functions = plt_functions.unwrap().context("failed to load plt functions")?;
-    let functions = vec![file_functions, plt_functions].concat();
+    let functions = vec![functions, plt_functions].concat();
 
     let checker = FunctionChecker::new(
         &orig_elf,

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -83,20 +83,20 @@ fn main() -> Result<()> {
 
     let functions = functions.unwrap().context("failed to load function CSV")?;
     let plt_functions = plt_functions.unwrap().context("failed to load plt functions")?;
-    let functions = vec![functions, plt_functions].concat();
+    let all_functions = vec![functions.clone(), plt_functions].concat();
 
     let checker = FunctionChecker::new(
         &orig_elf,
         &decomp_elf,
         &decomp_symtab,
         decomp_glob_data_table,
-        &functions,
+        &all_functions,
         version,
     )
     .context("failed to construct FunctionChecker")?;
 
     if let Some(func) = &args.function {
-        check_single(&checker, &functions, func, &args)?;
+        check_single(&checker, &functions, &all_functions, func, &args)?;
     } else {
         check_all(&checker, &functions, &args)?;
     }
@@ -334,6 +334,7 @@ fn check_function(
 fn check_single(
     checker: &FunctionChecker,
     functions: &[functions::Info],
+    all_functions: &[functions::Info],
     fn_to_check: &str,
     args: &Args,
 ) -> Result<()> {
@@ -384,7 +385,7 @@ fn check_single(
         show_asm_differ(function, name, &args.other_args, version)?;
 
         maybe_mismatch =
-            rediff_function_after_differ(functions, &orig_fn, name, &maybe_mismatch, version)
+            rediff_function_after_differ(all_functions, &orig_fn, name, &maybe_mismatch, version)
                 .context("failed to rediff")?;
     }
 


### PR DESCRIPTION
Upstreaming the proposed changes from https://github.com/LynxDev2/nx-decomp-tools/pull/2.

1. Add new mismatch type `InternalError`, to be used when something unexpected happens within viking. Should hopefully never be shown to the user, but I would rather display a cryptic mismatch (that can be ignored by marking as "mismatching") rather than silently fail and mark it as matching (existing behaviour, probably still happens for some things)
2. Parse more things from the ELF, namely `.dynsym` and `.dynstrtab` to resolve names of `.plt`-references
3. Add functions from `.plt` to list of functions, to allow them to be "resolved" when comparing. For example, if some code calls `cos(...)`, `cos` is not listed in the `file_list.yml`, so should rather be imported from `.plt`.
4. Finally, when checking function calls, pay more attention to the failures: If the name within the file list of a called function is empty, but we expect it to be implemented, it's likely the name being missing from the list. If a given name does not occur in the decomp elf, we likely called the wrong function, and the actual target function never got called/emitted. Finally, if the address of the expected function call and the actual call target mismatch, that's the standard "chose the wrong function" scenario.
5. For games without symbols (like BotW) that do not want to check for the names of `plt` references to be correct, this behaviour can be disabled in `config.toml` using `check_unimplemented_references = false`.

The logic in 4 was mostly in place before as well, but has now been extended with multiple `plt_X_to_X` calls, which take over when the "standard functions" return no results: Functions in the PLT have a symbol, but it's pointing to `0` instead of the actual function, so name/address have to be mapped via relocations.

Note, this still introduces 390 errors in BotW's run of `tools/check`. This is because previously, a missing/wrong name on an implemented function has been silently ignored. This means that not only the references to these functions were ignored, but the functions themselves were not checked in the first place either. These need to be fixed before BotW can update to the current version of `viking` (once this is merged).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/38)
<!-- Reviewable:end -->
