### PR TITLE
fix: don't parse the header as a symbol

### DIFF
--- a/viking/src/checks.rs
+++ b/viking/src/checks.rs
@@ -33,7 +33,7 @@ impl KnownDataSymbolMap {
 
     fn load(&mut self, csv_path: &Path, decomp_symtab: &elf::SymbolTableByName) -> Result<()> {
         let mut reader = csv::ReaderBuilder::new()
-            .has_headers(false)
+            .has_headers(true)
             .quoting(false)
             .from_path(csv_path)?;
         for (line, maybe_record) in reader.records().enumerate() {


### PR DESCRIPTION
Without this patch, attempting to run `check` throws:
```
Error: failed to construct FunctionChecker

Caused by:
    invalid digit found in string
```

A quick check by printing inside parse_address shows that it's attempting to parse "Address" as an address, meaning it's attempting to parse the CSV header as a symbol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/40)
<!-- Reviewable:end -->
