### PR TITLE
viking: Check metadata of symbols in `.dynsym`

### DIFF
--- a/viking/src/checks.rs
+++ b/viking/src/checks.rs
@@ -569,3 +569,68 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
             .or_else(|| elf::plt_addr_to_name(self.decomp_elf, decomp_addr))
     }
 }
+
+
+#[derive(Debug)]
+pub enum SymbolMismatchCause {
+    // st_size
+    Size(u64, u64),
+    // st_info
+    Bind(u8, u8),
+    Type(u8, u8),
+    // st_other
+    Visibility(u8, u8),
+}
+
+impl std::fmt::Display for SymbolMismatchCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match &self {
+            Self::Size(_, _) => "Size",
+            Self::Bind(_, _) => "Bind",
+            Self::Type(_, _) => "Type",
+            Self::Visibility(_, _) => "Visibility",
+        };
+        let orig = match &self {
+            Self::Size(orig_size, _) => orig_size.to_string(),
+            Self::Bind(orig_bind, _) => goblin::elf::sym::bind_to_str(*orig_bind).to_string(),
+            Self::Type(orig_type, _) => goblin::elf::sym::type_to_str(*orig_type).to_string(),
+            Self::Visibility(orig_vis, _) => goblin::elf::sym::visibility_to_str(*orig_vis).to_string(),
+        };
+        let decomp = match &self {
+            Self::Size(_, decomp_size) => decomp_size.to_string(),
+            Self::Bind(_, decomp_bind) => goblin::elf::sym::bind_to_str(*decomp_bind).to_string(),
+            Self::Type(_, decomp_type) => goblin::elf::sym::type_to_str(*decomp_type).to_string(),
+            Self::Visibility(_, decomp_vis) => goblin::elf::sym::visibility_to_str(*decomp_vis).to_string(),
+        };
+        write!(
+            f,
+            "incorrect {name}; expected to see {orig}\n\
+            --> decomp contains {decomp} instead",
+            name = name,
+            orig = orig,
+            decomp = decomp,
+        )
+    }
+}
+
+pub fn check_symbol(symbol: &goblin::elf::Sym, decomp_symbol: &goblin::elf::Sym) -> Result<Option<SymbolMismatchCause>> {
+    // mismatching function size will cause issues in FunctionChecker already, so ignore here
+    if symbol.st_size != decomp_symbol.st_size && !symbol.is_function() {
+        return Ok(Some(SymbolMismatchCause::Size(symbol.st_size, decomp_symbol.st_size)))
+    }
+
+    // st_info
+    if symbol.st_bind() != decomp_symbol.st_bind() {
+        return Ok(Some(SymbolMismatchCause::Bind(symbol.st_bind(), decomp_symbol.st_bind())))
+    }
+    if symbol.st_type() != decomp_symbol.st_type() {
+        return Ok(Some(SymbolMismatchCause::Type(symbol.st_type(), decomp_symbol.st_type())))
+    }
+
+    // st_other
+    if symbol.st_visibility() != decomp_symbol.st_visibility() {
+        return Ok(Some(SymbolMismatchCause::Visibility(symbol.st_visibility(), decomp_symbol.st_visibility())))
+    }
+
+    Ok(None)
+}

--- a/viking/src/elf.rs
+++ b/viking/src/elf.rs
@@ -142,10 +142,10 @@ pub struct SymbolStringTable<'elf> {
 }
 
 impl<'elf> SymbolStringTable<'elf> {
-    pub fn from_elf(elf: &'elf OwnedElf) -> Result<Self> {
+    pub fn from_elf(elf: &'elf OwnedElf, sh_type: u32) -> Result<Self> {
         let bytes = &*elf.as_owner().1;
         for shdr in &elf.section_headers {
-            if shdr.sh_type == section_header::SHT_SYMTAB {
+            if shdr.sh_type == sh_type {
                 let table_hdr = elf
                     .section_headers
                     .get(shdr.sh_link as usize)
@@ -186,14 +186,14 @@ pub fn is_undefined_sym(sym: &Sym) -> bool {
 }
 
 pub fn find_function_symbol_by_name(elf: &OwnedElf, name: &str) -> Result<Sym> {
-    let strtab = SymbolStringTable::from_elf(elf)?;
+    let strtab = SymbolStringTable::from_elf(elf, section_header::SHT_SYMTAB)?;
 
     for symbol in elf.syms.iter().filter(filter_out_useless_syms) {
         if name == strtab.get_string(symbol.st_name) {
             return Ok(symbol);
         }
     }
-    bail!("unknown function")
+    bail!("Unknown function: {:?}", name)
 }
 
 pub fn make_symbol_map_by_name(elf: &OwnedElf) -> Result<SymbolTableByName<'_>> {
@@ -202,9 +202,24 @@ pub fn make_symbol_map_by_name(elf: &OwnedElf) -> Result<SymbolTableByName<'_>> 
         Default::default(),
     );
 
-    let strtab = SymbolStringTable::from_elf(elf)?;
+    let strtab = SymbolStringTable::from_elf(elf, section_header::SHT_SYMTAB)?;
 
     for symbol in elf.syms.iter().filter(filter_out_useless_syms) {
+        map.entry(strtab.get_string(symbol.st_name))
+            .or_insert(symbol);
+    }
+    Ok(map)
+}
+
+pub fn make_dynsym_map_by_name(elf: &OwnedElf) -> Result<SymbolTableByName<'_>> {
+    let mut map = SymbolTableByName::with_capacity_and_hasher(
+        elf.dynsyms.iter().filter(filter_out_useless_syms).count(),
+        Default::default(),
+    );
+
+    let strtab = SymbolStringTable::from_elf(elf, section_header::SHT_DYNSYM)?;
+
+    for symbol in elf.dynsyms.iter().filter(filter_out_useless_syms) {
         map.entry(strtab.get_string(symbol.st_name))
             .or_insert(symbol);
     }
@@ -228,7 +243,7 @@ pub fn make_addr_to_name_map(elf: &OwnedElf) -> Result<AddrToNameMap<'_>> {
         Default::default(),
     );
 
-    let strtab = SymbolStringTable::from_elf(elf)?;
+    let strtab = SymbolStringTable::from_elf(elf, section_header::SHT_SYMTAB)?;
 
     for symbol in elf.syms.iter().filter(filter_out_useless_syms) {
         map.entry(symbol.st_value)

--- a/viking/src/repo.rs
+++ b/viking/src/repo.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub default_version: Option<String>,
     pub decomp_me: Option<ConfigDecompMe>,
     pub check_unimplemented_references: Option<bool>,
+    pub check_symbols: Option<bool>,
 }
 
 #[derive(serde::Deserialize)]

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -118,7 +118,9 @@ fn main() -> Result<()> {
 
     check_all(&checker, &all_functions, &args)?;
 
-    check_symbols(&orig_dynsym, &decomp_dynsym)?;
+    if repo::get_config().check_symbols.unwrap_or(true) {
+        check_symbols(&orig_dynsym, &decomp_dynsym)?;
+    }
 
     eprintln!("{}", "OK".green().bold());
     Ok(())

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -66,12 +66,16 @@ fn main() -> Result<()> {
     let mut decomp_glob_data_table = None;
     let mut functions = None;
     let mut plt_functions = None;
+    let mut orig_dynsym = None;
+    let mut decomp_dynsym = None;
 
     rayon::scope(|s| {
         s.spawn(|_| decomp_symtab = Some(elf::make_symbol_map_by_name(&decomp_elf)));
         s.spawn(|_| decomp_glob_data_table = Some(elf::build_glob_data_table(&decomp_elf)));
         s.spawn(|_| functions = Some(functions::get_functions(version)));
         s.spawn(|_| plt_functions = Some(elf::get_plt_functions(&orig_elf)));
+        s.spawn(|_| orig_dynsym = Some(elf::make_dynsym_map_by_name(&orig_elf)));
+        s.spawn(|_| decomp_dynsym = Some(elf::make_dynsym_map_by_name(&decomp_elf)));
     });
 
     let decomp_symtab = decomp_symtab
@@ -85,6 +89,15 @@ fn main() -> Result<()> {
     let plt_functions = plt_functions
         .unwrap()
         .context("failed to load plt functions")?;
+    
+    let orig_dynsym = orig_dynsym
+        .unwrap()
+        .context("failed to make original ELF dynsym map")?;
+
+    let decomp_dynsym = decomp_dynsym
+        .unwrap()
+        .context("failed to make decomp ELF dynsym map")?;
+
     let all_functions = vec![functions.clone(), plt_functions].concat();
 
     let checker = FunctionChecker::new(
@@ -99,10 +112,15 @@ fn main() -> Result<()> {
 
     if let Some(func) = &args.function {
         check_single(&checker, &functions, &all_functions, func, &args)?;
-    } else {
-        check_all(&checker, &functions, &args)?;
+        return Ok(())
+
     }
 
+    check_all(&checker, &all_functions, &args)?;
+
+    check_symbols(&orig_dynsym, &decomp_dynsym)?;
+
+    eprintln!("{}", "OK".green().bold());
     Ok(())
 }
 
@@ -475,7 +493,6 @@ fn check_all(checker: &FunctionChecker, functions: &[functions::Info], args: &Ar
     if failed.load(atomic::Ordering::Relaxed) {
         bail!("found at least one error");
     } else {
-        eprintln!("{}", "OK".green().bold());
         Ok(())
     }
 }
@@ -753,4 +770,97 @@ fn check_mismatch_comment(
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+pub enum SymbolMismatchCause {
+    // st_size
+    Size(u64, u64),
+    // st_info
+    Bind(u8, u8),
+    Type(u8, u8),
+    // st_other
+    Visibility(u8, u8),
+}
+
+impl std::fmt::Display for SymbolMismatchCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match &self {
+            Self::Size(_, _) => "Size",
+            Self::Bind(_, _) => "Bind",
+            Self::Type(_, _) => "Type",
+            Self::Visibility(_, _) => "Visibility",
+        };
+        let orig = match &self {
+            Self::Size(orig_size, _) => orig_size.to_string(),
+            Self::Bind(orig_bind, _) => goblin::elf::sym::bind_to_str(*orig_bind).to_string(),
+            Self::Type(orig_type, _) => goblin::elf::sym::type_to_str(*orig_type).to_string(),
+            Self::Visibility(orig_vis, _) => goblin::elf::sym::visibility_to_str(*orig_vis).to_string(),
+        };
+        let decomp = match &self {
+            Self::Size(_, decomp_size) => decomp_size.to_string(),
+            Self::Bind(_, decomp_bind) => goblin::elf::sym::bind_to_str(*decomp_bind).to_string(),
+            Self::Type(_, decomp_type) => goblin::elf::sym::type_to_str(*decomp_type).to_string(),
+            Self::Visibility(_, decomp_vis) => goblin::elf::sym::visibility_to_str(*decomp_vis).to_string(),
+        };
+        write!(
+            f,
+            "incorrect {name}; expected to see {orig}\n\
+            --> decomp contains {decomp} instead",
+            name = name,
+            orig = orig,
+            decomp = decomp,
+        )
+    }
+}
+
+fn check_symbols(
+    orig_dynsym: &elf::SymbolTableByName,
+    decomp_dynsym: &elf::SymbolTableByName,
+) -> Result<()> {
+
+    let mut mismatching = false;
+
+    for (name, symbol) in orig_dynsym.iter() {
+        let Some(decomp_symbol) = decomp_dynsym.get(name) else {
+            continue;
+        };
+
+        if let Some(mismatch) = check_symbol(symbol, decomp_symbol)? {
+            mismatching = true;
+            ui::print_error(&format!(
+                "symbol {} is different between the original and decomp ELF:\n{}",
+                ui::format_symbol_name(name),
+                mismatch
+            ));
+        }
+    }
+
+    if mismatching {
+        bail!("found at least one error");
+    } else {
+        Ok(())
+    }
+}
+
+pub fn check_symbol(symbol: &goblin::elf::Sym, decomp_symbol: &goblin::elf::Sym) -> Result<Option<SymbolMismatchCause>> {
+    // mismatching function size will cause issues in FunctionChecker already, so ignore here
+    if symbol.st_size != decomp_symbol.st_size && !symbol.is_function() {
+        return Ok(Some(SymbolMismatchCause::Size(symbol.st_size, decomp_symbol.st_size)))
+    }
+
+    // st_info
+    if symbol.st_bind() != decomp_symbol.st_bind() {
+        return Ok(Some(SymbolMismatchCause::Bind(symbol.st_bind(), decomp_symbol.st_bind())))
+    }
+    if symbol.st_type() != decomp_symbol.st_type() {
+        return Ok(Some(SymbolMismatchCause::Type(symbol.st_type(), decomp_symbol.st_type())))
+    }
+
+    // st_other
+    if symbol.st_visibility() != decomp_symbol.st_visibility() {
+        return Ok(Some(SymbolMismatchCause::Visibility(symbol.st_visibility(), decomp_symbol.st_visibility())))
+    }
+
+    Ok(None)
 }

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -8,6 +8,7 @@ use goblin::elf::sym::STT_FUNC;
 use itertools::Itertools;
 use lexopt::prelude::*;
 use rayon::prelude::*;
+use viking::checks::check_symbol;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -774,48 +775,6 @@ fn check_mismatch_comment(
     Ok(())
 }
 
-#[derive(Debug)]
-pub enum SymbolMismatchCause {
-    // st_size
-    Size(u64, u64),
-    // st_info
-    Bind(u8, u8),
-    Type(u8, u8),
-    // st_other
-    Visibility(u8, u8),
-}
-
-impl std::fmt::Display for SymbolMismatchCause {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match &self {
-            Self::Size(_, _) => "Size",
-            Self::Bind(_, _) => "Bind",
-            Self::Type(_, _) => "Type",
-            Self::Visibility(_, _) => "Visibility",
-        };
-        let orig = match &self {
-            Self::Size(orig_size, _) => orig_size.to_string(),
-            Self::Bind(orig_bind, _) => goblin::elf::sym::bind_to_str(*orig_bind).to_string(),
-            Self::Type(orig_type, _) => goblin::elf::sym::type_to_str(*orig_type).to_string(),
-            Self::Visibility(orig_vis, _) => goblin::elf::sym::visibility_to_str(*orig_vis).to_string(),
-        };
-        let decomp = match &self {
-            Self::Size(_, decomp_size) => decomp_size.to_string(),
-            Self::Bind(_, decomp_bind) => goblin::elf::sym::bind_to_str(*decomp_bind).to_string(),
-            Self::Type(_, decomp_type) => goblin::elf::sym::type_to_str(*decomp_type).to_string(),
-            Self::Visibility(_, decomp_vis) => goblin::elf::sym::visibility_to_str(*decomp_vis).to_string(),
-        };
-        write!(
-            f,
-            "incorrect {name}; expected to see {orig}\n\
-            --> decomp contains {decomp} instead",
-            name = name,
-            orig = orig,
-            decomp = decomp,
-        )
-    }
-}
-
 fn check_symbols(
     orig_dynsym: &elf::SymbolTableByName,
     decomp_dynsym: &elf::SymbolTableByName,
@@ -843,26 +802,4 @@ fn check_symbols(
     } else {
         Ok(())
     }
-}
-
-pub fn check_symbol(symbol: &goblin::elf::Sym, decomp_symbol: &goblin::elf::Sym) -> Result<Option<SymbolMismatchCause>> {
-    // mismatching function size will cause issues in FunctionChecker already, so ignore here
-    if symbol.st_size != decomp_symbol.st_size && !symbol.is_function() {
-        return Ok(Some(SymbolMismatchCause::Size(symbol.st_size, decomp_symbol.st_size)))
-    }
-
-    // st_info
-    if symbol.st_bind() != decomp_symbol.st_bind() {
-        return Ok(Some(SymbolMismatchCause::Bind(symbol.st_bind(), decomp_symbol.st_bind())))
-    }
-    if symbol.st_type() != decomp_symbol.st_type() {
-        return Ok(Some(SymbolMismatchCause::Type(symbol.st_type(), decomp_symbol.st_type())))
-    }
-
-    // st_other
-    if symbol.st_visibility() != decomp_symbol.st_visibility() {
-        return Ok(Some(SymbolMismatchCause::Visibility(symbol.st_visibility(), decomp_symbol.st_visibility())))
-    }
-
-    Ok(None)
 }

--- a/viking/src/tools/list_symbols.rs
+++ b/viking/src/tools/list_symbols.rs
@@ -3,7 +3,10 @@ use argh::FromArgs;
 use colored::Colorize;
 use goblin::{
     elf::Sym,
-    elf64::sym::{STT_FILE, STT_NOTYPE, STT_OBJECT},
+    elf64::{
+        section_header::SHT_SYMTAB,
+        sym::{STT_FILE, STT_NOTYPE, STT_OBJECT},
+    },
 };
 use itertools::Itertools;
 use viking::{elf, functions};
@@ -41,7 +44,7 @@ fn main() -> Result<()> {
     let known_funcs = functions::make_known_function_name_map(&functions);
 
     let elf = elf::load_decomp_elf(args.version.as_deref())?;
-    let symtab = elf::SymbolStringTable::from_elf(&elf)?;
+    let symtab = elf::SymbolStringTable::from_elf(&elf, SHT_SYMTAB)?;
 
     let filter = |sym: &Sym| {
         if sym.st_type() == STT_NOTYPE && sym.st_value != 0 {


### PR DESCRIPTION
requires #38 to be merged first.

In this PR, a new check is added that ensures that symbols listed in the `.dynsym` section of the executable match in metadata between the original and decompiled binary.

This includes the defined symbol `size`, `info` (type and binding) and `other` (visibility) fields included in the ELF. Any mismatch is reported similar to mismatches in function contents, requesting the user to adjust their code to fix attributes, visibility and similar.

We iterate over all symbols in the original elf, then try looking up the corresponding symbol in the decomp elf. This also means that additional symbols in the decomp elf are ignored (introduced/kept due to `-g` or more exports), and ensures that games without symbols do not show errors here either (no symbols = no mismatches possible).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/42)
<!-- Reviewable:end -->
