### PR TITLE
viking: don't print last line in reference diff if not known

### DIFF
--- a/viking/src/checks.rs
+++ b/viking/src/checks.rs
@@ -98,7 +98,7 @@ fn get_data_symbol_csv_path(version: Option<&str>) -> Result<PathBuf> {
 #[derive(Debug)]
 pub struct ReferenceDiff {
     pub referenced_symbol: u64,
-    pub expected_ref_in_decomp: u64,
+    pub expected_ref_in_decomp: Option<u64>,
     pub actual_ref_in_decomp: u64,
 
     pub expected_symbol_name: String,
@@ -107,17 +107,25 @@ pub struct ReferenceDiff {
 
 impl std::fmt::Display for ReferenceDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "incorrect reference; expected to see {ref} {ref_name}\n\
-            --> decomp source code is referencing {actual} {actual_name}\n\
-            --> expected to see {expected} to match original code",
+        writeln!(f,
+            "incorrect reference; expected to see {ref} {ref_name}",
             ref=ui::format_address(self.referenced_symbol),
             ref_name=ui::format_symbol_name(&self.expected_symbol_name),
-            expected=ui::format_address(self.expected_ref_in_decomp),
-            actual=ui::format_address(self.actual_ref_in_decomp),
-            actual_name=ui::format_symbol_name(&self.actual_symbol_name),
-        )
+        )?;
+        writeln!(
+            f,
+            "--> decomp source code is referencing {actual} {actual_name}",
+            actual = ui::format_address(self.actual_ref_in_decomp),
+            actual_name = ui::format_symbol_name(&self.actual_symbol_name),
+        )?;
+        if let Some(expected) = self.expected_ref_in_decomp {
+            writeln!(
+                f,
+                "--> expected to see {expected} to match original code",
+                expected = ui::format_address(expected),
+            )?;
+        }
+        Ok(())
     }
 }
 
@@ -422,7 +430,10 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
 
     /// Returns None on success and a MismatchCause on failure.
     fn check_function_call(&self, orig_addr: u64, decomp_addr: u64) -> Option<MismatchCause> {
-        if !repo::get_config().check_unimplemented_references.unwrap_or(true) {
+        if !repo::get_config()
+            .check_unimplemented_references
+            .unwrap_or(true)
+        {
             // 0x10 = size of one plt entry
             if elf::is_in_section(self.decomp_plt_section?, decomp_addr, 0x10) {
                 // we are deliberately ignoring PLT references, so do not check their target
@@ -432,9 +443,10 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
 
         let Some(info) = self.known_functions.get(&orig_addr) else {
             // should not happen, but loudly complain (and only fail single function) if it still happens
-            return Some(MismatchCause::InternalError(
-                format!("failed to resolve orig function at address {:x}", orig_addr)
-            ))
+            return Some(MismatchCause::InternalError(format!(
+                "failed to resolve orig function at address {:x}",
+                orig_addr
+            )));
         };
         let name = info.name.as_str();
         if name.is_empty() {
@@ -442,33 +454,37 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
             let actual_symbol_name = self.translate_decomp_addr_to_name(decomp_addr);
             return Some(MismatchCause::FunctionCall(ReferenceDiff {
                 referenced_symbol: orig_addr,
-                expected_ref_in_decomp: 0,
+                expected_ref_in_decomp: None,
                 actual_ref_in_decomp: decomp_addr,
                 expected_symbol_name: "<unnamed function>".to_string(),
                 actual_symbol_name: actual_symbol_name.unwrap_or("unknown").to_string(),
-            }))
+            }));
         }
-        let Some(expected) = self.decomp_symtab.get(name).map(|sym| sym.st_value)
-                .or_else(|| elf::plt_name_to_addr(self.decomp_elf, name)) else {
+        let Some(expected) = self
+            .decomp_symtab
+            .get(name)
+            .map(|sym| sym.st_value)
+            .or_else(|| elf::plt_name_to_addr(self.decomp_elf, name))
+        else {
             let actual_symbol_name = self.translate_decomp_addr_to_name(decomp_addr);
             return Some(MismatchCause::FunctionCall(ReferenceDiff {
                 referenced_symbol: orig_addr,
-                expected_ref_in_decomp: 0,
+                expected_ref_in_decomp: None,
                 actual_ref_in_decomp: decomp_addr,
                 expected_symbol_name: name.to_string(),
                 actual_symbol_name: actual_symbol_name.unwrap_or("unknown").to_string(),
-            }))
+            }));
         };
 
         if decomp_addr != expected {
             let actual_symbol_name = self.translate_decomp_addr_to_name(decomp_addr);
             return Some(MismatchCause::FunctionCall(ReferenceDiff {
                 referenced_symbol: orig_addr,
-                expected_ref_in_decomp: expected,
+                expected_ref_in_decomp: Some(expected),
                 actual_ref_in_decomp: decomp_addr,
                 expected_symbol_name: name.to_string(),
                 actual_symbol_name: actual_symbol_name.unwrap_or("unknown").to_string(),
-            }))
+            }));
         }
 
         None
@@ -491,7 +507,7 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
 
             Some(MismatchCause::DataReference(ReferenceDiff {
                 referenced_symbol: orig_addr,
-                expected_ref_in_decomp: expected,
+                expected_ref_in_decomp: Some(expected),
                 actual_ref_in_decomp: decomp_addr,
                 expected_symbol_name: symbol.name.to_string(),
                 actual_symbol_name: actual_symbol_name.unwrap_or("unknown").to_string(),
@@ -548,6 +564,8 @@ impl<'a, 'functions, 'orig_elf, 'decomp_elf>
             let map = elf::make_addr_to_name_map(self.decomp_elf).ok();
             map.unwrap_or_default()
         });
-        map.get(&decomp_addr).copied().or_else(|| elf::plt_addr_to_name(self.decomp_elf, decomp_addr))
+        map.get(&decomp_addr)
+            .copied()
+            .or_else(|| elf::plt_addr_to_name(self.decomp_elf, decomp_addr))
     }
 }

--- a/viking/src/elf.rs
+++ b/viking/src/elf.rs
@@ -22,7 +22,10 @@ use memmap::{Mmap, MmapOptions};
 use owning_ref::OwningHandle;
 use rustc_hash::FxHashMap;
 
-use crate::{repo, functions::{Info, Status}};
+use crate::{
+    functions::{Info, Status},
+    repo,
+};
 
 pub type OwnedElf = OwningHandle<Box<(File, Mmap)>, Box<Elf<'static>>>;
 pub type SymbolTableByName<'a> = HashMap<&'a str, goblin::elf::Sym>;
@@ -102,7 +105,8 @@ fn parse_elf_faster(bytes: &[u8]) -> Result<Elf<'_>> {
         let hash_offset = dyn_info.hash.context("no hash")? as usize;
         // number of symbols (entries in .hash section) is stored at offset 4
         // (https://github.com/m4b/goblin/blob/86de3b4b04c49e2f80ec9ebd8f60c059b7213fb7/src/elf/mod.rs#L519)
-        let num_syms = u32::from_le_bytes(bytes[hash_offset+4..hash_offset+8].try_into()?) as usize;
+        let num_syms =
+            u32::from_le_bytes(bytes[hash_offset + 4..hash_offset + 8].try_into()?) as usize;
         elf.dynsyms = Symtab::parse(bytes, dyn_info.symtab, num_syms, ctx)?;
 
         elf.dynstrtab = Strtab::parse(bytes, dyn_info.strtab, dyn_info.strsz, 0x0)?;
@@ -312,10 +316,18 @@ pub fn get_plt_functions(elf: &OwnedElf) -> Result<Vec<crate::functions::Info>> 
     for (idx, reloc) in elf.pltrelocs.iter().enumerate() {
         // each PLT entry is 0x10 bytes, and the first (reserved) entry is twice the size
         let addr = plt_section.sh_addr + (idx as u64 + 2) * 0x10;
-        let sym = elf.dynsyms.get(reloc.r_sym).context("Failed to get dynsym")?;
-        let name = elf.dynstrtab.get_at(sym.st_name).context("Failed to get dynstr")?;
+        let sym = elf
+            .dynsyms
+            .get(reloc.r_sym)
+            .context("Failed to get dynsym")?;
+        let name = elf
+            .dynstrtab
+            .get_at(sym.st_name)
+            .context("Failed to get dynstr")?;
         functions.push(Info {
-            addr: addr, size: 0x10, name: name.to_string(), 
+            addr: addr,
+            size: 0x10,
+            name: name.to_string(),
             status: Status::Library,
         });
     }
@@ -398,7 +410,11 @@ pub fn find_file_and_line_by_symbol(
 pub fn plt_name_to_addr(elf: &OwnedElf, func_name: &str) -> Option<u64> {
     // find plt relocation for given function name
     let reloc_idx = elf.pltrelocs.iter().position(|reloc| {
-        elf.dynsyms.get(reloc.r_sym).map(|s| elf.dynstrtab.get_at(s.st_name)).flatten() == Some(func_name)
+        elf.dynsyms
+            .get(reloc.r_sym)
+            .map(|s| elf.dynstrtab.get_at(s.st_name))
+            .flatten()
+            == Some(func_name)
     })?;
 
     let plt_section = find_section(elf, ".plt").ok()?;
@@ -409,6 +425,8 @@ pub fn plt_addr_to_name(elf: &OwnedElf, addr: u64) -> Option<&str> {
     let plt_section = find_section(elf, ".plt").ok()?;
     let reloc_idx = (addr - plt_section.sh_addr) / 16 - 2;
     let reloc = elf.pltrelocs.get(reloc_idx as usize)?;
-    let name = elf.dynstrtab.get_at(elf.dynsyms.get(reloc.r_sym)?.st_name)?;
+    let name = elf
+        .dynstrtab
+        .get_at(elf.dynsyms.get(reloc.r_sym)?.st_name)?;
     Some(name)
 }

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -82,7 +82,9 @@ fn main() -> Result<()> {
         .context("failed to make global data table")?;
 
     let functions = functions.unwrap().context("failed to load function CSV")?;
-    let plt_functions = plt_functions.unwrap().context("failed to load plt functions")?;
+    let plt_functions = plt_functions
+        .unwrap()
+        .context("failed to load plt functions")?;
     let all_functions = vec![functions.clone(), plt_functions].concat();
 
     let checker = FunctionChecker::new(


### PR DESCRIPTION
Changed `expected_ref_in_decomp` to Option and don't print it if not found

Also ran `cargo fmt`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/43)
<!-- Reviewable:end -->
