### PR TITLE
setup: venv to manage python dependencies automatically

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,0 +1,10 @@
+ansiwrap==0.8.4
+capstone==5.0.9
+colorama==0.4.6
+cxxfilt==0.3.0
+Levenshtein==0.27.3
+python-Levenshtein==0.27.3
+RapidFuzz==3.14.5
+textwrap3==0.9.2
+toml==0.10.2
+watchdog==6.0.0

--- a/setup_venv.py
+++ b/setup_venv.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+USER_FRIENDLY_VENV_PATH = "tools/common/.venv"
+
+def enter_venv():
+    # check if already in venv (set below before execv)
+    if os.environ.get("NX_DECOMP_TOOLS_IN_VENV"):
+        return
+    venv_executable = Path(__file__).parent / ".venv" / "bin" / "python"
+    if sys.executable == venv_executable:
+        return
+    setup_python_venv()
+    os.environ["NX_DECOMP_TOOLS_IN_VENV"] = "1"
+    os.execv(venv_executable, [venv_executable, *sys.argv])
+
+def fail(error: str):
+    print(">>> " + error)
+    sys.exit(1)
+
+def setup_python_venv():
+    tools_root = Path(__file__).parent
+    venv_path = tools_root / ".venv"
+    venv_python = venv_path / "bin" / "python"
+    venv_pip = venv_path / "bin" / "pip"
+
+    if not venv_path.is_dir(follow_symlinks=True):
+        if venv_path.exists():
+            fail(f"error: {USER_FRIENDLY_VENV_PATH} exists and is not a directory!")
+        # create venv
+        print(f">>> creating {USER_FRIENDLY_VENV_PATH}")
+        subprocess.check_call([sys.executable, "-m", "venv", venv_path])
+    else:
+        print(f">>> {USER_FRIENDLY_VENV_PATH} is already setup")
+        # still fall through to ensure pip modules are up-to-date
+
+
+    # for some reason just installing with pip install . fail to build
+    # levenshtein, so we will use the shim approach
+    print(">>> installing python dependencies")
+    try:
+        requirements = tools_root / "pip-requirements.txt"
+        subprocess.check_call([
+            venv_pip,
+            "install",
+            "-r",
+            requirements
+        ])
+        # create shim for asm-differ
+        # note the cd is important so diff_settings is processed correctly
+        asm_differ_shim = venv_path / "bin" / "asm-differ"
+        asm_differ_shim.write_text(f"""#!/usr/bin/env bash
+set -euo pipefail
+PYTHON='{venv_python}'
+cd '{tools_root}'
+exec "$PYTHON" asm-differ/diff.py "$@"
+""")
+        os.chmod(asm_differ_shim, 0o755) # rwxr-xr-x
+
+    except:
+        print(sys.exc_info()[0])
+        fail(f"error: delete {USER_FRIENDLY_VENV_PATH} and try again")

--- a/viking/src/tools/check.rs
+++ b/viking/src/tools/check.rs
@@ -9,11 +9,12 @@ use itertools::Itertools;
 use lexopt::prelude::*;
 use rayon::prelude::*;
 use std::cell::RefCell;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::Command;
 use std::sync::atomic;
 use std::sync::Mutex;
 use viking::checks::FunctionChecker;
@@ -176,7 +177,7 @@ All further arguments are forwarded onto asm-differ.
 asm-differ arguments:"
 );
 
-    let differ_path = repo::get_tools_path()?.join("asm-differ").join("diff.py");
+    let differ_path = get_asm_differ_path()?;
 
     // By default, invoking asm-differ using std::process:Process doesn't seem to allow argparse
     // (the python module asm-differ uses to print its help text) to correctly determine the number of columns in the host terminal.
@@ -186,7 +187,7 @@ asm-differ arguments:"
         Err(_) => 240,
     };
 
-    let output = std::process::Command::new(&differ_path)
+    let output = Command::new(&differ_path)
         .current_dir(repo::get_tools_path()?)
         .arg("--help")
         .env("COLUMNS", num_columns.to_string())
@@ -470,14 +471,13 @@ fn check_all(checker: &FunctionChecker, functions: &[functions::Info], args: &Ar
         &new_function_statuses.lock().unwrap(),
         args.version.as_deref(),
     )
-    .with_context(|| "failed to update function statuses")?;
+    .context("failed to update function statuses")?;
 
     if failed.load(atomic::Ordering::Relaxed) {
         bail!("found at least one error");
-    } else {
-        eprintln!("{}", "OK".green().bold());
-        Ok(())
     }
+    eprintln!("{}", "OK".green().bold());
+    Ok(())
 }
 
 #[cold]
@@ -608,8 +608,8 @@ fn show_asm_differ(
     differ_args: &[String],
     version: Option<&str>,
 ) -> Result<()> {
-    let differ_path = repo::get_tools_path()?.join("asm-differ").join("diff.py");
-    let mut cmd = std::process::Command::new(&differ_path);
+    let differ_path = get_asm_differ_path()?;
+    let mut cmd = Command::new(&differ_path);
 
     cmd.current_dir(repo::get_tools_path()?)
         .arg("-I")
@@ -627,6 +627,18 @@ fn show_asm_differ(
         .with_context(|| format!("failed to launch asm-differ: {:?}", &differ_path))?;
 
     Ok(())
+}
+
+fn get_asm_differ_path() -> Result<PathBuf> {
+    let base_path = repo::get_tools_path()?;
+
+    // use the virtual env if one is setup with setup_python_venv()
+    let differ_path_venv = base_path.join(".venv/bin/asm-differ");
+    if differ_path_venv.exists() {
+        return Ok(differ_path_venv);
+    }
+
+    Ok(base_path.join("asm-differ/diff.py"))
 }
 
 fn rediff_function_after_differ(


### PR DESCRIPTION
I started using `uv` to manage python projects and it doesn't come with a nice way to install global pip packages. I think it would be nice to have the setup script make a python venv automatically and install the necessary dependencies, which will make the setup more streamlined as well. Another benefit is the wheel versions are locked

With this change, downstream projects just need to insert this snippet in `tools/setup.py` at the top (before importing other modules - this will setup the venv and `execv` into the venv)
```python
from common.setup_venv import enter_venv
if __name__ == "__main__":
    enter_venv()
```

Now people setting up the project just need to have python installed (to run the setup script itself), and a venv will be created at `tools/common/venv` automatically.

A shim for `asm-differ` is created for viking to call. If this shim does not exist, it will fallback to the current behavior of trying to call diff.py using global python. This way the change is fully backward-compatible and everything should behave as-is if the above snippet is not used. Projects can opt-in to the new behavior by updating the setup script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/44)
<!-- Reviewable:end -->
