### PR TITLE
Modify `setup_common` to match new nx2elf

### DIFF
--- a/setup_common.py
+++ b/setup_common.py
@@ -14,19 +14,22 @@ ROOT = Path(__file__).parent.parent.parent
 def get_target_path(version = config.get_default_version()):
     return config.get_versioned_data_path(version) / "main.nso"
 
+def get_uncompressed_target_path(version = config.get_default_version()):
+    return config.get_versioned_data_path(version) / "main.uncompressed.nso"
+
 def get_target_elf_path(version = config.get_default_version()):
     return config.get_versioned_data_path(version) / "main.elf"
-
 
 def fail(error: str):
     print(">>> " + error)
     sys.exit(1)
 
-def _convert_nso_to_elf(nso_path: Path, export_uncompressed_nso=True):
+def _convert_nso_to_elf(nso_path: Path, elf_out_path = get_target_elf_path(), uncompressed_nso_out_path = get_uncompressed_target_path()):
     print(">>>> converting NSO to ELF...")
-    command = [tools.find_tool("nx2elf"), str(nso_path)];
-    if export_uncompressed_nso:
+    command = [tools.find_tool("nx2elf"), str(nso_path), "--export-elf", elf_out_path];
+    if uncompressed_nso_out_path is not None:
         command.append("--export-uncompressed")
+        command.append(uncompressed_nso_out_path)
     subprocess.check_call(command)
 
 


### PR DESCRIPTION
Around a year ago https://github.com/MonsterDruide1/nx2elf/ was changed so that instead of the ELF and uncompressed NSO ending up next to the input NSO, the output paths for those two files now needed to be manually specified. This has two benefits:
1. The files don't need to be moved later with code/manually
2. This fixes the problem where setup would previously fail when the input NSO was on a read only file system since it would attempt to write to that file system

So this PR changes `_convert_nso_to_elf` accordingly to support the latest `nx2elf`. `nx-decomp-tools-binaries` needs to be updated separately in a later PR for projects like botw to be able to update to this version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nx-decomp-tools/45)
<!-- Reviewable:end -->
